### PR TITLE
feat: add xblock handler api

### DIFF
--- a/edx_courses_api/permissions.py
+++ b/edx_courses_api/permissions.py
@@ -1,0 +1,27 @@
+from rest_framework.permissions import IsAuthenticated, BasePermission
+
+class IsSiteAdminUser(BasePermission):
+    """
+    Allow access to only site admins if in multisite mode or staff or superuser
+    if in standalone mode
+    """
+
+    def has_permission(self, request, view):
+        return is_site_admin_user(request)
+
+def is_active_staff_or_superuser(user):
+    """
+    Checks if user is active staff or superuser.
+    """
+    return user and user.is_active and (user.is_staff or user.is_superuser)
+
+def is_site_admin_user(request):
+    """
+    Determines if the requesting user has access to site admin data
+    """
+    if not request.user.is_active:
+        return False
+
+    if is_active_staff_or_superuser(request.user):
+        return True
+

--- a/edx_courses_api/urls.py
+++ b/edx_courses_api/urls.py
@@ -4,10 +4,14 @@ URLs for edx_courses_api.
 from django.conf import settings
 from django.conf.urls import url
 
-from .views import CourseView, hide, show, export, export_output, export_status
+from .views import CourseView, hide, show, export, export_output, export_status, submit_studio_edits, xblock_handler
 
 urlpatterns = [
     url(r'^{}/$'.format(settings.COURSE_KEY_PATTERN), CourseView.as_view(), name='course'),
+    url(r'^{}/xblocks/(?P<usage_key_string>.*?)/handler/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$'.format(settings.COURSE_KEY_PATTERN),
+        xblock_handler,
+        name='xblock_handler'),
+    # url(r'^{}/xblocks/(?P<usage_key_string>.*?)/handler/submit_studio_edits/$'.format(settings.COURSE_KEY_PATTERN), submit_studio_edits, name='submit_studio_edits'),
     url(r'^{}/hide/$'.format(settings.COURSE_KEY_PATTERN), hide, name='hide_course'),
     url(r'^{}/show/$'.format(settings.COURSE_KEY_PATTERN), show, name='show_course'),
     url(r'^{}/export/$'.format(settings.COURSE_KEY_PATTERN), export, name='export'),

--- a/edx_courses_api/urls.py
+++ b/edx_courses_api/urls.py
@@ -4,14 +4,16 @@ URLs for edx_courses_api.
 from django.conf import settings
 from django.conf.urls import url
 
-from .views import CourseView, hide, show, export, export_output, export_status, submit_studio_edits, xblock_handler
+from .views import CourseView, hide, show, export, export_output, export_status, xblock_handler, xblock_item_handler
 
 urlpatterns = [
     url(r'^{}/$'.format(settings.COURSE_KEY_PATTERN), CourseView.as_view(), name='course'),
+    url(r'^{}/xblocks/{}?$'.format(settings.COURSE_KEY_PATTERN, settings.USAGE_KEY_PATTERN),
+        xblock_item_handler,
+        name='xblock_item_handler'),
     url(r'^{}/xblocks/(?P<usage_key_string>.*?)/handler/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$'.format(settings.COURSE_KEY_PATTERN),
         xblock_handler,
         name='xblock_handler'),
-    # url(r'^{}/xblocks/(?P<usage_key_string>.*?)/handler/submit_studio_edits/$'.format(settings.COURSE_KEY_PATTERN), submit_studio_edits, name='submit_studio_edits'),
     url(r'^{}/hide/$'.format(settings.COURSE_KEY_PATTERN), hide, name='hide_course'),
     url(r'^{}/show/$'.format(settings.COURSE_KEY_PATTERN), show, name='show_course'),
     url(r'^{}/export/$'.format(settings.COURSE_KEY_PATTERN), export, name='export'),


### PR DESCRIPTION
This PR added the following APIs

- `POST ${STUDIO_URL}/sn-api/courses/{course_key}/xblocks/{usage_key}/handler/{handler}/`

This can be use to trigger the [submit_studio_edit](https://github.com/edx/xblock-utils/blob/master/xblockutils/studio_editable.py#L203) handler action. It works the same as editing the course from Studio UI, but different authentication method

- `GET|POST|PUT ${STUDIO_URL}/sn-api/courses/{course_key}/xblocks/{usage_key}`

This can be used to do a lot of things. We just want the "publish" feature tho

Also added a permission class to prevent non-admin from accessing these privileged endpoints