### PR TITLE
Rename cms.djangoapps.contentstore.views.[item] to [block]

### DIFF
--- a/edx_courses_api/views.py
+++ b/edx_courses_api/views.py
@@ -28,7 +28,7 @@ from xblock.django.request import django_to_webob_request, webob_to_django_respo
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
 from contentstore.views.item import StudioEditModuleRuntime
 from xblock.exceptions import NoSuchHandlerError
-from cms.djangoapps.contentstore.views.item import _get_module_info, _get_xblock, _save_xblock
+from cms.djangoapps.contentstore.views.block import _get_module_info, _get_xblock, _save_xblock
 
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateGenerationCourseSetting


### PR DESCRIPTION
The file `cms.djangoapps.contentstore.views.item.py` in [edx-platform](https://github.com/openedx/edx-platform) was renamed to `cms.djangoapps.contentstore.views.block.py` in [this commit](https://github.com/openedx/edx-platform/commit/d338f00e396d9d485e02e55b5e91875ba97a2fa7).

Therefore, we should change all references
```py
import cms.djangoapps.contentstore.views.item
```

to

```py
import cms.djangoapps.contentstore.views.block
```